### PR TITLE
isArray and isDictionary checks in the CordovaBridge were not working

### DIFF
--- a/CordovaFramework/CordovaFramework/Classes/CDVBridge.m
+++ b/CordovaFramework/CordovaFramework/Classes/CDVBridge.m
@@ -30,7 +30,8 @@
 - (BOOL) isArray:(id)item
 {
     id win = [self.webView windowScriptObject];
-    NSNumber* result = [win callWebScriptMethod:@"CordovaBridgeUtil.isArray" withArguments:[NSArray arrayWithObject:item]];
+    WebScriptObject* bridgeUtil = [win evaluateWebScript:@"CordovaBridgeUtil"];
+    NSNumber* result = [bridgeUtil callWebScriptMethod:@"isArray" withArguments:[NSArray arrayWithObject:item]];
 
     return [result boolValue];
 }
@@ -38,7 +39,8 @@
 - (BOOL) isDictionary:(id)item
 {
     id win = [self.webView windowScriptObject];
-    NSNumber* result = [win callWebScriptMethod:@"CordovaBridgeUtil.isObject" withArguments:[NSArray arrayWithObject:item]];
+    WebScriptObject* bridgeUtil = [win evaluateWebScript:@"CordovaBridgeUtil"];
+    NSNumber* result = [bridgeUtil callWebScriptMethod:@"isObject" withArguments:[NSArray arrayWithObject:item]];
     return [result boolValue];
 }
 


### PR DESCRIPTION
Therefore making it impossible to pass in arrays or objects from Javascript.
`callWebScriptMethod` can only call immediate properties on an object.

BTW, I signed & sent the icla.pdf, so hopefully you can accept this pull request.
