### PR TITLE
Update OSX Support for CLI

### DIFF
--- a/templates/scripts/cordova/.gitignore
+++ b/templates/scripts/cordova/.gitignore
@@ -1,0 +1,2 @@
+!build
+!lib

--- a/templates/scripts/cordova/build
+++ b/templates/scripts/cordova/build
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#
+# compile and launch a Cordova/iOS project to the simulator
+#
+
+CORDOVA_PATH=$( cd "$( dirname "$0" )" && pwd -P)
+PROJECT_PATH="$(dirname "$CORDOVA_PATH")"
+XCODEPROJ=$( ls "$PROJECT_PATH" | grep .xcodeproj  )
+PROJECT_NAME=$(basename "$XCODEPROJ" .xcodeproj)
+
+source "$CORDOVA_PATH/check_reqs"
+cd "$PROJECT_PATH"
+
+CONFIGURATION=Debug
+CLEAN=
+OPEN=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --debug) ;;
+        --release) CONFIGURATION=Release;;
+        --device) OPEN=1 ;; # ignored for osx
+        --emulator) OPEN=1 ;; # ignored for osx
+        --clean) CLEAN=clean;;
+        *) echo "Unrecognized flag: $1"; exit 2;;
+    esac
+    shift
+done
+
+xcodebuild \
+    -xcconfig "$CORDOVA_PATH/build.xcconfig" \
+    -project "$PROJECT_NAME.xcodeproj" \
+    -target "$PROJECT_NAME" \
+    -configuration "$CONFIGURATION" \
+    $CLEAN build
+
+if (($OPEN)); then
+    echo "Starting $PROJECT_NAME.app ..."
+    open "$PROJECT_PATH/build/$PROJECT_NAME.app"
+fi

--- a/templates/scripts/cordova/lib/copy-www-build-step.sh
+++ b/templates/scripts/cordova/lib/copy-www-build-step.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+#
+#    Licensed to the Apache Software Foundation (ASF) under one
+#    or more contributor license agreements.  See the NOTICE file
+#    distributed with this work for additional information
+#    regarding copyright ownership.  The ASF licenses this file
+#    to you under the Apache License, Version 2.0 (the
+#    "License"); you may not use this file except in compliance
+#    with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing,
+#    software distributed under the License is distributed on an
+#    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#    KIND, either express or implied.  See the License for the
+#    specific language governing permissions and limitations
+#    under the License.
+#
+#
+#   This script copies the www directory into the Xcode project.
+#
+#   This script should not be called directly.
+#   It is called as a build step from Xcode.
+
+SRC_DIR="www/"
+DST_DIR="$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Contents/Resources/www"
+COPY_HIDDEN=
+ORIG_IFS=$IFS
+IFS=$(echo -en "\n\b")
+
+if [[ -z "$BUILT_PRODUCTS_DIR" ]]; then
+  echo "The script is meant to be run as an Xcode build step and relies on env variables set by Xcode."
+  exit 1
+fi
+if [[ ! -e "$SRC_DIR" ]]; then
+  echo "Path does not exist: $SRC_DIR"
+  exit 1
+fi
+
+if [[ -n $COPY_HIDDEN ]]; then
+  alias do_find='find "$SRC_DIR"'
+else
+  alias do_find='find -L "$SRC_DIR" -name ".*" -prune -o'
+fi
+
+time (
+# Code signing files must be removed or else there are
+# resource signing errors.
+rm -rf "$DST_DIR" \
+       "$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/_CodeSignature" \
+       "$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/PkgInfo" \
+       "$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/embedded.mobileprovision"
+
+# Directories
+for p in $(do_find -type d -print); do
+  subpath="${p#$SRC_DIR}"
+  mkdir "$DST_DIR$subpath" || exit 1
+done
+
+# Symlinks
+for p in $(do_find -type l -print); do
+  subpath="${p#$SRC_DIR}"
+  source=$(readlink $SRC_DIR$subpath)
+  sourcetype=$(stat -f "%HT%SY" $source)
+  if [ "$sourcetype" = "Directory" ]; then
+    mkdir "$DST_DIR$subpath" || exit 2
+  else
+    rsync -a "$source" "$DST_DIR$subpath" || exit 3
+  fi
+done
+
+# Files
+for p in $(do_find -type f -print); do
+  subpath="${p#$SRC_DIR}"
+  if ! ln "$SRC_DIR$subpath" "$DST_DIR$subpath" 2>/dev/null; then
+    rsync -a "$SRC_DIR$subpath" "$DST_DIR$subpath" || exit 4
+  fi
+done
+
+# Copy the config.xml file.
+cp -f "${PROJECT_FILE_PATH%.xcodeproj}/config.xml" "$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME/Contents/Resources"
+
+# Copy the icons (probably the wrong place)
+# process icons if present
+if [ -d "${SRC_DIR}/res/osx" ]; then
+    ICON_DIR=$(dirname "${PRODUCT_SETTINGS_PATH}")/Images.xcassets/AppIcon.appiconset
+    echo "Copying icons to $ICON_DIR"
+    cp "${SRC_DIR}/res/osx/"icon-*.png "${ICON_DIR}"
+fi
+
+)
+IFS=$ORIG_IFS
+

--- a/templates/scripts/cordova/lib/install-device
+++ b/templates/scripts/cordova/lib/install-device
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Valid values for "--target" (case insensitive):
+#     "iPhone (Retina 3.5-inch)" (default)
+#     "iPhone (Retina 4-inch)"
+#     "iPhone"
+#     "iPad"
+#     "iPad (Retina)"
+
+LIB_PATH=$( cd "$( dirname "$0" )" && pwd -P)
+CORDOVA_PATH="$(dirname "$LIB_PATH")"
+PROJECT_PATH="$(dirname "$CORDOVA_PATH")"
+XCODEPROJ=$( ls "$PROJECT_PATH" | grep .xcodeproj  )
+PROJECT_NAME=$(basename "$XCODEPROJ" .xcodeproj)
+
+DEVICE_APP_PATH="$PROJECT_PATH/build/device/$PROJECT_NAME.app"
+
+source "$CORDOVA_PATH/check_reqs"
+
+if [ ! -d "$DEVICE_APP_PATH" ]; then
+	echo "Project '$DEVIC_APP_PATH' is not built."
+    exit 1
+fi
+
+
+IOS_DEPLOY_MIN_VERSION="1.0.4"
+IOS_DEPLOY_LOCATION=$(which ios-deploy)
+if [ $? != 0 ]; then
+    echo -e "\033[31mError: ios-deploy was not found. Please download, build and install version $IOS_DEPLOY_MIN_VERSION or greater from https://github.com/phonegap/ios-deploy into your path. Or 'npm install -g ios-deploy' using node.js: http://nodejs.org/\033[m"; exit 1;
+	exit 1
+fi
+
+IOS_DEPLOY_VERSION=$(ios-deploy --version)
+if [[ "$IOS_DEPLOY_VERSION" < "$IOS_DEPLOY_MIN_VERSION" ]]; then
+	echo "Cordova needs ios-deploy version $IOS_DEPLOY_MIN_VERSION or greater, you have version $IOS_DEPLOY_VERSION."
+	exit 1
+fi
+
+# if we got here, we can deploy the app, then exit success
+ios-deploy -b "$DEVICE_APP_PATH"
+exit 0

--- a/templates/scripts/cordova/lib/install-emulator
+++ b/templates/scripts/cordova/lib/install-emulator
@@ -1,0 +1,126 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Valid values for "--target" (case insensitive):
+#     "iPhone (Retina 3.5-inch)" (default)
+#     "iPhone (Retina 4-inch)"
+#     "iPhone"
+#     "iPad"
+#     "iPad (Retina)"
+
+OPTION_RESULT=()
+TARGET="iPhone (Retina 3.5-inch)"
+TARGET_FLAG='--family iphone --retina'
+
+# separates "key=value", sets an array with 0th index as key, 1st index as value
+_parseOption() 
+{
+    local ARG=$@
+    OIFS=$IFS
+    IFS='='
+
+    OPTION_RESULT=()
+    for i in ${ARG[@]}
+    do
+      OPTION_RESULT+=($i)
+    done
+
+    IFS=$OIFS
+}
+
+# parses key=value arguments
+_parseArgs()
+{
+  for arg in "$@"
+  do
+    _parseOption ${arg}
+    case "${OPTION_RESULT[0]}" in
+      "--target")
+        TARGET=${OPTION_RESULT[1]}
+        ;;
+    esac
+  done
+}
+
+_parseArgs "$@"
+
+# lowercase the target string
+TARGET_LC=`echo $TARGET | tr '[:upper:]' '[:lower:]'` 
+
+# remember the comparison is lowercase
+case "$TARGET_LC" in
+  	"iphone (retina 3.5-inch)")
+    TARGET_FLAG="--family iphone --retina"
+    ;;
+    "iphone (retina 4-inch)")
+    TARGET_FLAG="--family iphone --retina --tall"
+    ;;
+    # --64bit not supportted by ios-sim yet
+    #"iphone retina (4-inch 64-bit)")
+    #TARGET_FLAG="--family iphone --retina --tall --64bit"
+    #;;
+    "iphone")
+    TARGET_FLAG="--family iphone"
+    ;;
+    "ipad")
+    TARGET_FLAG="--family ipad"
+    ;;
+    "ipad (retina)")
+    TARGET_FLAG="--family ipad --retina"
+    ;;
+esac
+
+LIB_PATH=$( cd "$( dirname "$0" )" && pwd -P)
+CORDOVA_PATH="$(dirname "$LIB_PATH")"
+PROJECT_PATH="$(dirname "$CORDOVA_PATH")"
+XCODEPROJ=$( ls "$PROJECT_PATH" | grep .xcodeproj  )
+PROJECT_NAME=$(basename "$XCODEPROJ" .xcodeproj)
+
+SIMULATOR_APP_PATH="$PROJECT_PATH/build/emulator/$PROJECT_NAME.app"
+
+source "$CORDOVA_PATH/check_reqs"
+
+if [ ! -d "$SIMULATOR_APP_PATH" ]; then
+	echo "Project '$SIMULATOR_APP_PATH' is not built."
+    exit 1
+fi
+
+if [ ! -d "$SIMULATOR_APP_PATH" ]; then
+	echo "$SIMULATOR_APP_PATH not found to emulate."
+	exit 1
+fi
+
+IOS_SIM_MIN_VERSION="1.7"
+IOS_SIM_LOCATION=$(which ios-sim)
+if [ $? != 0 ]; then
+    echo -e "\033[31mError: ios-sim was not found. Please download, build and install version $IOS_SIM_MIN_VERSION or greater from https://github.com/phonegap/ios-sim into your path. Or 'npm install -g ios-sim' using node.js: http://nodejs.org/\033[m"; exit 1;
+	exit 1
+fi
+
+IOS_SIM_VERSION=$(ios-sim --version)
+
+if [[ "$IOS_SIM_VERSION" < "$IOS_SIM_MIN_VERSION" ]]; then
+	echo "Cordova needs ios-sim version $IOS_SIM_MIN_VERSION or greater, you have version $IOS_SIM_VERSION."
+	exit 1
+fi
+
+# launch using ios-sim
+ios-sim launch "$SIMULATOR_APP_PATH" --stderr "$CORDOVA_PATH/console.log" --stdout "$CORDOVA_PATH/console.log" $TARGET_FLAG --exit
+
+

--- a/templates/scripts/cordova/lib/list-devices
+++ b/templates/scripts/cordova/lib/list-devices
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+system_profiler SPUSBDataType | sed -n -e '/iPad/,/Serial/p' | grep "Serial Number:" | awk -F ": " '{print $2 " iPad"}'
+system_profiler SPUSBDataType | sed -n -e '/iPhone/,/Serial/p' | grep "Serial Number:" | awk -F ": " '{print $2 " iPhone"}'

--- a/templates/scripts/cordova/lib/list-emulator-images
+++ b/templates/scripts/cordova/lib/list-emulator-images
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Valid values for "--target" (case insensitive):
+#     "iPhone Retina (3.5-inch)" (default)
+#     "iPhone Retina (4-inch)"
+#     "iPhone"
+#     "iPad"
+#     "iPad Retina"
+
+set -e
+
+echo \""iPhone (Retina 3.5-inch)"\"
+echo \""iPhone (Retina 4-inch)"\"
+
+# this assumes Xcode 5 minimum not supported by ios-sim yet
+# echo \""iPhone (Retina 4-inch 64-bit)"\"
+
+echo \""iPhone"\"
+echo \""iPad"\"
+echo \""iPad (Retina)"\"
+
+
+

--- a/templates/scripts/cordova/lib/list-started-emulators
+++ b/templates/scripts/cordova/lib/list-started-emulators
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Valid values for "--target" (case insensitive):
+#     "iPhone (Retina 3.5-inch)" (default)
+#     "iPhone (Retina 4-inch)"
+#     "iPhone"
+#     "iPad"
+#     "iPad (Retina)"
+
+set -e
+
+SIM_RUNNING=$(ps aux | grep -i "[i]Phone Simulator" | wc -l)
+if [ $SIM_RUNNING == 0 ]; then
+    echo "No emulators are running."
+    exit 1
+fi
+
+SIM_ID=`defaults read com.apple.iphonesimulator "SimulateDevice"`
+echo \"$SIM_ID\"

--- a/templates/scripts/cordova/lib/sim.applescript
+++ b/templates/scripts/cordova/lib/sim.applescript
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+tell application "System Events"
+	set UI elements enabled to true
+end tell
+
+tell application "iPhone Simulator"
+    activate
+end tell
+
+tell application "System Events"
+    tell process "iPhone Simulator"
+    click menu item "$DEVICE_NAME" of menu 1 of menu item "Device" of menu 1 of menu bar item "Hardware" of menu bar 1
+    click menu item "Home" of menu 1 of menu bar item "Hardware" of menu bar 1
+    end tell
+end tell

--- a/templates/scripts/cordova/lib/start-emulator
+++ b/templates/scripts/cordova/lib/start-emulator
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Valid values for "--target" (case insensitive):
+#     "iPhone (Retina 3.5-inch)" (default)
+#     "iPhone (Retina 4-inch)"
+#     "iPhone"
+#     "iPad"
+#     "iPad (Retina)"
+
+set -e
+
+
+DEFAULT_TARGET="iPhone Retina (3.5-inch)"
+TARGET=${1:-$DEFAULT_TARGET}
+LIB_PATH=$( cd "$( dirname "$0" )" && pwd -P)
+
+SCPT=`sed -e "s/\\$DEVICE_NAME/$TARGET/g" "$LIB_PATH/sim.applescript"`
+osascript -e "$SCPT"


### PR DESCRIPTION
fixes the following issues and allows to successfully clean,build,run osx platform on cli
- CB-2920 Add a ./cordova/clean project-level script for OSX
- CB-2934 Add a ./cordova/build project-level script for OSX
- CB-2946 Add a ./cordova/run project-level script for OSX
- CB-2802 add a ./bin/check_reqs script to OS X
- CB-2803 Add CLI scripts for OS X
- CB-3343 OSX - add version script
