### PR TITLE
CB-4319 localStorage database is relocated when restarting app on OSX

### DIFF
--- a/CordovaLib/CordovaLib/Classes/CDVViewController.h
+++ b/CordovaLib/CordovaLib/Classes/CDVViewController.h
@@ -56,3 +56,16 @@
 - (void)registerPlugin:(CDVPlugin*)plugin withPluginName:(NSString*)pluginName;
 
 @end
+
+// add private web preferences
+@interface WebPreferences (WebPrivate)
+
+- (BOOL)webGLEnabled;
+- (void)setWebGLEnabled:(BOOL)enabled;
+
+- (BOOL)localStorageEnabled;
+- (void)setLocalStorageEnabled:(BOOL)localStorageEnabled;
+
+- (NSString *)_localStorageDatabasePath;
+- (void)_setLocalStorageDatabasePath:(NSString *)path;
+@end

--- a/templates/project/__CDV_PRODUCT_NAME__/Classes/MainViewController.m
+++ b/templates/project/__CDV_PRODUCT_NAME__/Classes/MainViewController.m
@@ -66,17 +66,6 @@
     [super awakeFromNib];
     
     // Implement this method to handle any initialization after your window controller's window has been loaded from its nib file.
-
-    // enable HTML5 webStorage
-    WebPreferences* prefs = [self.webView preferences];
-    if ([prefs respondsToSelector:@selector(_setLocalStorageDatabasePath:)]) {
-        NSString* webStoragePath = @"~/Library/Application Support/__CDV_PRODUCT_NAME__";
-        [prefs performSelector:@selector(_setLocalStorageDatabasePath:) withObject:webStoragePath];
-        NSLog(@"WebStoragePath is '%@', modify in MainViewController.m.", webStoragePath);
-    }
-    if ([prefs respondsToSelector:@selector(setLocalStorageEnabled:)]) {
-        [prefs performSelector:@selector(setLocalStorageEnabled:) withObject:[NSNumber numberWithBool:YES]];
-    }
 }
 
 @end

--- a/templates/project/__CDV_PRODUCT_NAME__/config.xml
+++ b/templates/project/__CDV_PRODUCT_NAME__/config.xml
@@ -16,10 +16,8 @@
     <preference name="PageLength" value="0" />
     <preference name="PaginationBreakingMode" value="page" />
     <preference name="PaginationMode" value="unpaginated" />
-    <feature name="LocalStorage">
-        <param name="ios-package" value="CDVLocalStorage" />
-    </feature>
-    <name>Pong</name>
+    <preference name="OSXLocalStoragePath" value="~/Library/Application Support/__CDV_PRODUCT_NAME__" />
+    <name>__CDV_PRODUCT_NAME__</name>
     <description>
         A sample Apache Cordova application that responds to the deviceready event.
     </description>


### PR DESCRIPTION
fixes:
- initialize web storage earlier
- read location from config.xml
- add fallback with bundleId if missing
- add missing placeholders in config.xml template
