### PR TITLE
Fix prompt submission bug

### DIFF
--- a/CordovaLib/CordovaLib/Classes/CDVWebViewDelegate.m
+++ b/CordovaLib/CordovaLib/Classes/CDVWebViewDelegate.m
@@ -129,7 +129,7 @@
     [alert setAccessoryView:input];
 
     NSInteger button = [alert runModal];
-    if (button == NSAlertDefaultReturn) {
+    if (button == NSAlertFirstButtonReturn) {
         [input validateEditing];
         return [input stringValue];
     }


### PR DESCRIPTION
Fixes an issue where clicking "OK" in a pop-up prompt does not return any value (despite being entered). The previous button-value checked was the constant NSAlertDefaultReturn, but since the NSAlert was created with the 'init' constructor, the runModal method will return one of NSAlert{first,second,third}ButtonReturn constants.