### PR TITLE
CB-12339: handle re-open app window

### DIFF
--- a/bin/templates/project/__PROJECT_NAME__/Classes/AppDelegate.m
+++ b/bin/templates/project/__PROJECT_NAME__/Classes/AppDelegate.m
@@ -44,4 +44,14 @@
 
 }
 
+- (BOOL)applicationShouldHandleReopen:(NSApplication *)app hasVisibleWindows:(BOOL)visibleWindows
+{
+  if (visibleWindows) {
+    [self.window orderFront:self];
+  } else {
+    [self.window makeKeyAndOrderFront:self];
+  }
+  return YES;
+}
+
 @end


### PR DESCRIPTION
### Platforms affected
osx

### What does this PR do?
When the app icon in the dock is clicked: re-opens the app window when if the app is closed. Brings the app window to the front if the app is running.

### What testing has been done on this change?
Manual verification.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
  * I don't have much experience testing UX. Would like pointers if tests are required for this feature.
