### PR TITLE
CB-13304: forward non file:// URLs to system

### DIFF
--- a/CordovaLib/CordovaLib/Classes/CDVWebViewDelegate.m
+++ b/CordovaLib/CordovaLib/Classes/CDVWebViewDelegate.m
@@ -83,9 +83,15 @@
 #pragma mark WebPolicyDelegate
 
 - (void) webView:(WebView*) sender decidePolicyForNavigationAction:(NSDictionary*) actionInformation request:(NSURLRequest*) request frame:(WebFrame*) frame decisionListener:(id <WebPolicyDecisionListener>) listener {
-    NSString* url = [[request URL] description];
-    NSLog(@"navigating to %@", url);
+  NSURL *url = [request URL];
+  NSLog(@"navigating to %@", url.description);
+  if ([@"file" isEqualToString:url.scheme]) {
+    // Open in app.
     [listener use];
+  } else {
+    // Intercept external requests and forward to the system.
+    [[NSWorkspace sharedWorkspace] openURL:url];
+  }
 }
 
 #pragma mark WebViewDelegate


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
OSX

### What does this PR do?
Forwards non file:// URL requests to the system instead of opening them inside the application.

### What testing has been done on this change?
Tested locally.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
