### PR TITLE
CB-13304: expose preference to control WebView navigation

### DIFF
--- a/CordovaLib/CordovaLib/Classes/CDVViewController.m
+++ b/CordovaLib/CordovaLib/Classes/CDVViewController.m
@@ -88,6 +88,7 @@
     WebPreferences* prefs = [self.webView preferences];
     [prefs setAutosaves:YES];
 
+    [self configureWebViewDelegate];
     [self configureWebDefaults:prefs];
     [self configureLocalStorage:prefs];
     [self configureWindowSize];
@@ -163,6 +164,14 @@
 
     // Initialize the plugin objects dict.
     self.pluginObjects = [[NSMutableDictionary alloc] initWithCapacity:20];
+}
+
+- (void)configureWebViewDelegate {
+    NSString *allowWebViewNavigation = [self.settings objectForKey:@"AllowWebViewNavigation"];
+    if (allowWebViewNavigation == nil) {
+        allowWebViewNavigation = @"true";  // Default to true for backwards compatibility.
+    }
+    self.webViewDelegate.allowWebViewNavigation = [allowWebViewNavigation boolValue];
 }
 
 /**

--- a/CordovaLib/CordovaLib/Classes/CDVWebViewDelegate.h
+++ b/CordovaLib/CordovaLib/Classes/CDVWebViewDelegate.h
@@ -30,6 +30,7 @@
 @interface CDVWebViewDelegate : NSObject {
 }
 
+@property (nonatomic) BOOL allowWebViewNavigation;
 @property (nonatomic, strong) CDVConsole* console;
 @property (nonatomic, strong) CDVBridge* bridge;
 @property (nonatomic,

--- a/CordovaLib/CordovaLib/Classes/CDVWebViewDelegate.m
+++ b/CordovaLib/CordovaLib/Classes/CDVWebViewDelegate.m
@@ -83,9 +83,15 @@
 #pragma mark WebPolicyDelegate
 
 - (void) webView:(WebView*) sender decidePolicyForNavigationAction:(NSDictionary*) actionInformation request:(NSURLRequest*) request frame:(WebFrame*) frame decisionListener:(id <WebPolicyDecisionListener>) listener {
-    NSString* url = [[request URL] description];
-    NSLog(@"navigating to %@", url);
+  NSURL *url = [request URL];
+  NSLog(@"navigating to %@", url.description);
+  if (self.allowWebViewNavigation || [@"file" isEqualToString:url.scheme]) {
+    // Open in-app if navigation is allowed in the WebView, or if this is a local file request.
     [listener use];
+  } else {
+    // Forward external requests to the system otherwise.
+    [[NSWorkspace sharedWorkspace] openURL:url];
+  }
 }
 
 #pragma mark WebViewDelegate

--- a/bin/templates/scripts/cordova/defaults.xml
+++ b/bin/templates/scripts/cordova/defaults.xml
@@ -23,6 +23,7 @@
 
     <!-- Preferences for OSX -->
     <preference name="AllowInlineMediaPlayback" value="true" />
+    <preference name="AllowWebViewNavigation" value="true" />
     <preference name="BackupWebStorage" value="cloud" />
     <preference name="DisallowOverscroll" value="false" />
     <preference name="EnableViewportScale" value="false" />


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
OSX

### What does this PR do?
Exposes a preference in config.xml, `AllowWebViewNavigation`,  to control navigation in the application's main WebView. If set to true (default), all URL requests are handled in-app; otherwise, forwards non file:// URL requests to the system instead of opening them inside the application.

This is a follow-up to #41.

### What testing has been done on this change?
Tested locally.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
