### PR TITLE
Added support for 1024x1024 app icon

### DIFF
--- a/bin/templates/scripts/cordova/lib/prepare.js
+++ b/bin/templates/scripts/cordova/lib/prepare.js
@@ -213,6 +213,7 @@ function handleIcons (projectConfig, platformRoot) {
     // See https://developer.apple.com/library/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/Designing.html
     // for application images sizes reference.
     var platformIcons = [
+        {dest: 'icon-1024x1024.png', width: 1024, height: 1024},
         {dest: 'icon-512x512.png', width: 512, height: 512},
         {dest: 'icon-256x256.png', width: 256, height: 256},
         {dest: 'icon-128x128.png', width: 128, height: 128},

--- a/tests/cdv-test-project/config.xml
+++ b/tests/cdv-test-project/config.xml
@@ -33,6 +33,7 @@
         <icon src="res/test-64x64.png" width="128" height="128" />
         <icon src="res/test-64x64.png" width="256" height="256" />
         <icon src="res/test-64x64.png" width="512" height="512" />
+        <icon src="res/test-64x64.png" width="1024" height="1024" />
     </platform>
 
 </widget>

--- a/tests/spec/platform.spec.js
+++ b/tests/spec/platform.spec.js
@@ -60,7 +60,8 @@ describe('platform add', function() {
             {name: 'icon-64x64.png', width: 64, height: 64},
             {name: 'icon-128x128.png', width: 128, height: 128},
             {name: 'icon-256x256.png', width: 256, height: 256},
-            {name: 'icon-512x512.png', width: 512, height: 512}
+            {name: 'icon-512x512.png', width: 512, height: 512},
+            {name: 'icon-1024x1024.png', width: 1024, height: 1024}
         ];
 
         var appIconsPath = path.join(test_platformPath, 'HelloCordova','Images.xcassets','AppIcon.appiconset');


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
osx


### What does this PR do?
Add support for 1024 icons

### What testing has been done on this change?
prepare test

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
