### PR TITLE
CB-13824: (osx) Swift 4 support

### DIFF
--- a/CordovaLib/CordovaLib/Classes/CDVViewController.m
+++ b/CordovaLib/CordovaLib/Classes/CDVViewController.m
@@ -304,6 +304,12 @@
     id obj = self.pluginObjects[className];
     if (!obj) {
         obj = [(CDVPlugin*) [NSClassFromString(className) alloc] initWithWebView:webView];
+        if (!obj) {
+            NSString* fullClassName = [NSString stringWithFormat:@"%@.%@",
+                                       NSBundle.mainBundle.infoDictionary[@"CFBundleExecutable"],
+                                       className];
+            obj = [(CDVPlugin*) [NSClassFromString(fullClassName) alloc] initWithWebView:webView];
+        }
 
         if (obj != nil) {
             [self registerPlugin:obj withClassName:className];


### PR DESCRIPTION
### Platforms affected
OSX

### What does this PR do?
Fixes a bug that prevents (Swift) plugins from being instantiated when running in Xcode 9/Swift 4.

### What testing has been done on this change?
Local verification with Xcode 9.2.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
