### PR TITLE
CB-13449: (osx) assign 1024x1024 app icon

### DIFF
--- a/bin/templates/project/__PROJECT_NAME__/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/bin/templates/project/__PROJECT_NAME__/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -57,6 +57,7 @@
         {
             "idiom": "mac",
             "size": "512x512",
+            "filename": "icon-1024x1024.png",
             "scale": "2x"
         }
     ],


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
OSX

### What does this PR do?

Assigns the 1024x1024 app icon as the 512x512@2x App Store icon in the Images.xcassets/AppIcon.appiconset template. e663fde2523f8fde0ff97c784f42bccdb9c3f139 added support to copy the icon but did not assign it.

### What testing has been done on this change?
Local verification of AppIcon in the Xcode project.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
