### PR TITLE
Added Travis CI OSX Image and Install cordova@latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: xcode9.4
 sudo: false
 
 env:
@@ -11,6 +12,7 @@ before_install:
   - nvm install $TRAVIS_NODE_VERSION
 
 install:
+  - npm install -g cordova@latest
   - npm install
 
 script:


### PR DESCRIPTION
### Platforms affected
none

### What does this PR do?
This repo has Travis CI configurations but is currently disabled from running. Once the repo is enabled to run, Travis CI fails because the tests require Cordova as a dependency.

This PR fixes the issues and prepare for Travis CI to be enabled.

Example Fail: https://travis-ci.org/erisu/cordova-osx/jobs/427950080#L1194

### What testing has been done on this change?
Passing Tests
- https://travis-ci.org/erisu/cordova-osx/builds/427956167