### PR TITLE
Updated License with a Valid SPDX License

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint": "node node_modules/eslint/bin/eslint bin && node node_modules/eslint/bin/eslint tests"
   },
   "author": "Apache Software Foundation",
-  "license": "Apache Version 2.0",
+  "license": "Apache-2.0",
   "dependencies": {
     "cordova-common": "^2.2.5",
     "nopt": "^3.0.6",


### PR DESCRIPTION
### Platforms affected
none

### What does this PR do?
Fixes the NPM's invalid license warning message. The `package.json` contains an invalid SPDX license expression.

**Warning Message**
```
npm WARN cordova-osx@4.1.0-dev license should be a valid SPDX license expression
```
**Changes**
`"license": "Apache Version 2.0",` becomes `"license": "Apache-2.0",`

### What testing has been done on this change?
- `npm i`