### PR TITLE
explicit plist@3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "cordova-common": "^3.0.0",
     "jasmine-spec-reporter": "^4.2.1",
     "nopt": "^3.0.6",
+    "plist": "^3.0.1",
     "q": "^1.4.1",
     "shelljs": "^0.5.3",
     "underscore": "^1.8.3",


### PR DESCRIPTION
needed since `require('plist')` is used in the following places (see <https://github.com/apache/cordova-osx/pull/66#issuecomment-421417938>):

* `bin/templates/scripts/cordova/lib/projectFile.js`
* `bin/templates/scripts/cordova/lib/prepare.js`

motivation is described in: <https://github.com/apache/cordova-osx/pull/66#issuecomment-421423781>