### PR TITLE
Only copy platform node_modules when created by binary

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -59,7 +59,8 @@ if (argv.argv.remain[2]) config.setName(argv.argv.remain[2]);
 
 var options = {
     link: argv.link,
-    customTemplate: argv.argv.remain[3]
+    customTemplate: argv.argv.remain[3],
+    copyPlatformNodeModules: true
 };
 
 Api.createPlatform(projectPath, config, options).done();

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -73,7 +73,7 @@ function copyJsAndCordovaLib (projectPath, projectName, use_shared) {
     });
 }
 
-function copyScripts (projectPath) {
+function copyScripts (projectPath, options) {
     var srcScriptsDir = path.join(ROOT, 'bin', 'templates', 'scripts', 'cordova');
     var destScriptsDir = path.join(projectPath, 'cordova');
 
@@ -83,7 +83,7 @@ function copyScripts (projectPath) {
     // Copy in the new ones.
     var binDir = path.join(ROOT, 'bin');
     shell.cp('-r', srcScriptsDir, projectPath);
-    shell.cp('-r', path.join(ROOT, 'node_modules'), destScriptsDir);
+    if (options.copyPlatformNodeModules) shell.cp('-r', path.join(ROOT, 'node_modules'), destScriptsDir);
 
     // Copy the check_reqs script
     shell.cp(path.join(binDir, 'check_reqs*'), destScriptsDir);
@@ -188,7 +188,7 @@ exports.createProject = function (project_path, package_name, project_name, opts
 
     // CordovaLib stuff
     copyJsAndCordovaLib(project_path, project_name, use_shared);
-    copyScripts(project_path);
+    copyScripts(project_path, opts);
 
     events.emit('log', generateDoneMessage('create', use_shared));
     return Q.resolve();


### PR DESCRIPTION
### Platforms affected
osx

### What does this PR do?
When platform is installed though CLI, `cordova platform add osx`, the copy node_modules step is no longer valid as dependencies are now at the project level.

The step is required only when the create binary from the platform repo is called.

https://github.com/apache/cordova/issues/32

### What testing has been done on this change?
- npm t
- https://travis-ci.org/erisu/cordova-osx/builds/452152403