### PR TITLE
npm test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ script:
   - node --version
   - npm --version
   - npm test
+  - npm run cover

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "cordova:platform"
   ],
   "scripts": {
-    "test": "npm run eslint && npm run test:coverage",
+    "cover": "npm run test:coverage",
+    "test": "npm run eslint && npm run test:component && npm run test:objc",
     "test:objc": "jasmine  --config=tests/spec/objc.json",
     "test:component": "jasmine --config=tests/spec/component.json",
     "test:coverage": "nyc jasmine --config=tests/spec/coverage.json",


### PR DESCRIPTION
* add test:objc to npm test script
* test:coverage separated from npm test script to npm cover script
* separate npm run cover step in .travis.yml

(more consistent with cordova-ios)

Travis CI is passing for these changes on my fork (<https://travis-ci.org/brodybits/cordova-osx/builds/460337012>)

part of "set up CI" (#71)