### PR TITLE
Move jasmine-spec-reporter to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -377,7 +377,8 @@
     "colors": {
       "version": "1.1.2",
       "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1195,6 +1196,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-4.2.1.tgz",
       "integrity": "sha512-FZBoZu7VE5nR7Nilzy+Np8KuVIOxF4oXDPDknehCYBDE080EnlPu0afdZNmpGDBRCUBv3mj5qgqCRmk6W/K8vg==",
+      "dev": true,
       "requires": {
         "colors": "1.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "cordova-common": "^3.0.0",
-    "jasmine-spec-reporter": "^4.2.1",
     "nopt": "^3.0.6",
     "q": "^1.4.1",
     "shelljs": "^0.5.3",
@@ -43,6 +42,7 @@
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^3.1.0",
     "jasmine": "^3.1.0",
+    "jasmine-spec-reporter": "^4.2.1",
     "nyc": "^13.0.1",
     "tmp": "0.0.33"
   },


### PR DESCRIPTION
(was added to the wrong place in 715ef0d - PR #73)

A quick review would be appreciated. I would like to merge this one before PR #66 or any others if possible.