### PR TITLE
Copy node_modules if the directory exists

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -83,7 +83,9 @@ function copyScripts (projectPath) {
     // Copy in the new ones.
     var binDir = path.join(ROOT, 'bin');
     shell.cp('-r', srcScriptsDir, projectPath);
-    shell.cp('-r', path.join(ROOT, 'node_modules'), destScriptsDir);
+
+    let nodeModulesDir = path.join(ROOT, 'node_modules');
+    if (fs.existsSync(nodeModulesDir)) shell.cp('-r', nodeModulesDir, destScriptsDir);
 
     // Copy the check_reqs script
     shell.cp(path.join(binDir, 'check_reqs*'), destScriptsDir);


### PR DESCRIPTION
### Platforms affected
osx

### What does this PR do?
- Copy the platform node_modules only when the folder exists.

https://github.com/apache/cordova/issues/32

### What testing has been done on this change?
- npm run eslint