### PR TITLE
set public CDVWindowSizeCommand.h

### DIFF
--- a/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
+++ b/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 		70BD67B818FFA12D00A1EFCF /* NSData+Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = 70BD679218FFA12D00A1EFCF /* NSData+Base64.m */; };
 		70BD67B918FFA12D00A1EFCF /* NSWindow+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 70BD679318FFA12D00A1EFCF /* NSWindow+Utils.h */; };
 		70BD67BA18FFA12D00A1EFCF /* NSWindow+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 70BD679418FFA12D00A1EFCF /* NSWindow+Utils.m */; };
-		CC6A01B9AD6ECF2D913FF418 /* CDVWindowSizeCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = CC6A03B1971BACCB9183AEFE /* CDVWindowSizeCommand.h */; };
+		CC6A01B9AD6ECF2D913FF418 /* CDVWindowSizeCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = CC6A03B1971BACCB9183AEFE /* CDVWindowSizeCommand.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CC6A03130738A1F299369195 /* CDVCursorMonitorService.m in Sources */ = {isa = PBXBuildFile; fileRef = CC6A07666A2CE3AE46F85AD6 /* CDVCursorMonitorService.m */; };
 		CC6A051516599A029D1ECA50 /* CDVMainWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = CC6A0F82EDAFA619D95D3392 /* CDVMainWindow.m */; };
 		CC6A0567D3BA91121C2D643C /* CookieJar.m in Sources */ = {isa = PBXBuildFile; fileRef = CC6A01435C5B9099EA0BF004 /* CookieJar.m */; };


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
OSX


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Actually plugins can not use cordova resize funcions, because they're not "exported". Thus plugin can not leverage the work of cordova framework.


### Description
<!-- Describe your changes in detail -->
To use cordova window resize functions, the command must be public, that is, callable by plugins. This change just make accessible the header.

Example of a plugin:
```swift
#import <Cordova/CDVWindowSizeCommand.h> // <--- to import the header must be public

- (void) makeFullscreen: (CDVInvokedUrlCommand *)command {
    BOOL fullscreen = [[command argumentAtIndex:0] boolValue];

    NSWindow* window = self.webView.window;
    if (fullscreen == NO) {
        [CDVWindowSizeCommand removeFullScreen:window];
    } else {
        [CDVWindowSizeCommand makeFullScreen:window];
    }
    
    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
}

```



### Testing
<!-- Please describe in detail how you tested your changes. -->
No test needed


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
