### PR TITLE
Add missing Foundation import

### DIFF
--- a/CordovaLib/CordovaLib/Classes/Commands/CDVJSON.h
+++ b/CordovaLib/CordovaLib/Classes/Commands/CDVJSON.h
@@ -17,6 +17,8 @@
  under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "OCUnusedMethodInspection"
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
osx

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Without the Foundation import, NSArray is not recognized, and doesn't compile.
This change fixes it.


### Description
<!-- Describe your changes in detail -->

Added the required import in order to compile sucesfully.

### Testing
<!-- Please describe in detail how you tested your changes. -->
no test needed


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [z] I've updated the documentation if necessary
