### PR TITLE
(osx) Make Cordova OSX build successfully on AppleSilicon target.

### DIFF
--- a/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
+++ b/CordovaLib/CordovaLib.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -426,6 +427,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = "include/$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				VALID_ARCHS = "i386 x86_64 arm64";
 			};
 			name = Debug;
 		};
@@ -438,6 +440,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = "include/$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				VALID_ARCHS = "i386 x86_64 arm64";
 			};
 			name = Release;
 		};

--- a/CordovaLib/CordovaLib/Classes/CDVBridge.m
+++ b/CordovaLib/CordovaLib/Classes/CDVBridge.m
@@ -74,7 +74,8 @@
     SEL normalSelector = NSSelectorFromString(methodName);
     if ([obj respondsToSelector:normalSelector]) {
         // [obj performSelector:normalSelector withObject:command];
-        objc_msgSend(obj, normalSelector, command);
+        void* (*msgSend)(id, SEL, CDVInvokedUrlCommand*) = (typeof(msgSend)) &objc_msgSend;
+        msgSend(obj, normalSelector, command);
     } else {
         // There's no method to call, so throw an error.
         NSLog(@"ERROR: Method '%@' not defined in Plugin '%@'", methodName, command.cmdClassName);

--- a/CordovaLib/CordovaLib/Classes/Commands/CDVCommandQueue.m
+++ b/CordovaLib/CordovaLib/Classes/Commands/CDVCommandQueue.m
@@ -143,7 +143,8 @@
     // Test for the legacy selector first in case they both exist.
     if ([obj respondsToSelector:normalSelector]) {
         // [obj performSelector:normalSelector withObject:command];
-        objc_msgSend(obj, normalSelector, command);
+        void* (*msgSend)(id, SEL, CDVInvokedUrlCommand*) = (typeof(msgSend)) &objc_msgSend;
+        msgSend(obj, normalSelector, command);
     } else {
         // There's no method to call, so throw an error.
         NSLog(@"ERROR: Method '%@' not defined in Plugin '%@'", methodName, command.cmdClassName);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

macOS ARM64 (AppleSilicon).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Build failed when targeting AppleSilicon because of using old prototype for objc_msgSend.

### Description
<!-- Describe your changes in detail -->

Closes #104 

- Added "arm64" as valid architecture
- Changed calls to objc_msgSend() to use new cast based prototype.

### Testing
<!-- Please describe in detail how you tested your changes. -->

- Built the library on XCode 12 with support for Universal Binaries and AppleSilicon
- Tested the universal binary build of the library on a Cordova OS X project

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
