### PR TITLE
Cast objc_msgSend when calling plugin methods

### DIFF
--- a/CordovaLib/CordovaLib/Classes/CDVBridge.m
+++ b/CordovaLib/CordovaLib/Classes/CDVBridge.m
@@ -74,7 +74,8 @@
     SEL normalSelector = NSSelectorFromString(methodName);
     if ([obj respondsToSelector:normalSelector]) {
         // [obj performSelector:normalSelector withObject:command];
-        objc_msgSend(obj, normalSelector, command);
+        void (*msgSend)(id, SEL, CDVInvokedUrlCommand*) = (void (*)(id, SEL, CDVInvokedUrlCommand*)) objc_msgSend;
+        msgSend(obj, normalSelector, command);
     } else {
         // There's no method to call, so throw an error.
         NSLog(@"ERROR: Method '%@' not defined in Plugin '%@'", methodName, command.cmdClassName);

--- a/CordovaLib/CordovaLib/Classes/Commands/CDVCommandQueue.m
+++ b/CordovaLib/CordovaLib/Classes/Commands/CDVCommandQueue.m
@@ -143,7 +143,8 @@
     // Test for the legacy selector first in case they both exist.
     if ([obj respondsToSelector:normalSelector]) {
         // [obj performSelector:normalSelector withObject:command];
-        objc_msgSend(obj, normalSelector, command);
+        void (*msgSend)(id, SEL, CDVInvokedUrlCommand*) = (void (*)(id, SEL, CDVInvokedUrlCommand*)) objc_msgSend;
+        msgSend(obj, normalSelector, command);
     } else {
         // There's no method to call, so throw an error.
         NSLog(@"ERROR: Method '%@' not defined in Plugin '%@'", methodName, command.cmdClassName);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

macOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #112.

### Description
<!-- Describe your changes in detail -->

Casts `objc_msgSend` before calling the method to be able to pass multiple arguments.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Verified that a cordova-osx project builds with this change.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
